### PR TITLE
add logo link to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -201,6 +201,14 @@
       ]
     },
     {
+      "category": "logo",
+      "values": [
+        {
+          "value": "eegnet-logo_0.png"
+        }
+      ]
+    },
+    {
       "category": "contact",
       "values": [
         {


### PR DESCRIPTION
This PR adds a `logo` value in the `extraProperties` section of the DATS.json file.