### PR TITLE
add origin_consortium value to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -196,6 +196,14 @@
         }
       ]
     },
+	{
+            "category": "origin_consortium",
+            "values": [
+                {
+                    "value": "EEGnet"
+                }
+            ]
+        },
     {
       "category": "logo",
       "values": [


### PR DESCRIPTION
This PR adds the value "EEGnet" to the `origin_consortium` field in DATS.json.